### PR TITLE
Update isPublic true for the updated image file

### DIFF
--- a/examples/nextjs-email-authentication/components/profile/ProfilePhoto.js
+++ b/examples/nextjs-email-authentication/components/profile/ProfilePhoto.js
@@ -50,6 +50,7 @@ function ProfilePhoto(props) {
           .bucket("profilePictures")
           .upload(fileName, image, {
             createBucket: true,
+            isPublic: true
           });
       }
       if (resultOfUpload.data) {


### PR DESCRIPTION
Unless this option is passed, the uploaded profile image remains private by default and does not show up and return a 403 error.  Set isPublic to true during image upload to make the profile photo visible.